### PR TITLE
[BUG-557] Fix broken rendering in iOS 11/WebKit

### DIFF
--- a/addon/components/super-modal.js
+++ b/addon/components/super-modal.js
@@ -13,7 +13,10 @@ export default Component.extend({
     'SuperModal',
   ],
 
-  classNameBindings: ['modifierClassName'],
+  classNameBindings: [
+    'modifierClassName',
+    'isIos11'
+  ],
 
   didInsertElement() {
     this._super(...arguments);


### PR DESCRIPTION
What Changed & Why
==================

WebKit in iOS 11 is affected by a [pretty serious bug](https://bugs.webkit.org/show_bug.cgi?id=176896) affecting inputs that have a parent with `position: fixed;`. The bug is still present in iOS 11.2.

This PR introduces a change where we detect for an iOS device running 11.xx, then applies a fairly gross hack to rectify the behaviour. This can be removed after we can be reasonably certain that people have upgraded away from this*.

*in a future where Apple has fixed the bug in WebKit + released a version of iOS containing the new version of WebKit

Related PRs
===========

https://github.com/PrecisionNutrition/es-student/pull/766

Screenshot
==========

See the [bug ticket](https://precisionnutrition.atlassian.net/browse/BUG-557) for screencasts.

QA
==

- [ ] Test sending a message to a coach on iOS 11 device:
  - [ ] The modal appears as expected
  - [ ] The subject line is autofocused (cursor appears there immediately after modal renders)
  - [ ] The input cursor appears where it is supposed to, both before and after inputting text
  - [ ] Scrolling the viewport after the message modal has been dismissed works properly

Bug/Ticket Tracker
==================

https://precisionnutrition.atlassian.net/browse/BUG-557

Documentation
=============

https://bugs.webkit.org/show_bug.cgi?id=176896

Who should be notified
======================

Holly Monster will probably be pretty happy about this one.
