### PR TITLE
Add closeButtonClassNames attr to customize close button classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ Elements
 Attributes
 ------------------------------------------------------------------------------
 
-* `modifierClassName`   - (Optional) Class name to add to the modal to differentiate between modals for styling purposes
-* `outerClassNames`     - (Optional) Class names to add to the `-outer` div
-* `overlayClassNames`   - (Optional) Class names to add to the `-overlay` div
-* `innerClassNames`     - (Optional) Class names to add to the `-inner` div
-* `disableOverlayClose` - (Optional) Remove the ability to click on the overlay to close the modal
+* `modifierClassName`     - (Optional) Class name to add to the modal to differentiate between modals for styling purposes
+* `outerClassNames`       - (Optional) Class names to add to the `-outer` div
+* `overlayClassNames`     - (Optional) Class names to add to the `-overlay` div
+* `innerClassNames`       - (Optional) Class names to add to the `-inner` div
+* `closeButtonClassNames` - (Optional) Class names to add to the close button `button`
+* `disableOverlayClose`   - (Optional) Remove the ability to click on the overlay to close the modal
 
 NOTES:
 ------------------------------------------------------------------------------

--- a/addon/templates/components/super-modal.hbs
+++ b/addon/templates/components/super-modal.hbs
@@ -11,7 +11,7 @@
   <div class="SuperModal-inner Grid-cell {{innerClassNames}}">
 
     {{#unless hideCloseButton}}
-      <button type="button" class="SuperModal-closeButton" {{action onClose}} data-test-selector="modal-close-button" aria-label="Close">&times;</button>
+      <button type="button" class="SuperModal-closeButton {{closeButtonClassNames}}" {{action onClose}} data-test-selector="modal-close-button" aria-label="Close">&times;</button>
     {{/unless}}
 
     {{yield}}


### PR DESCRIPTION
This PR adds a `closeButtonClassNames` attr to customize the close buttons class names, like we do with the other modal elements.