### PR TITLE
Fixes a memory leak in the Escape keyup handler

### DIFF
--- a/addon/components/super-modal.js
+++ b/addon/components/super-modal.js
@@ -16,13 +16,15 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    this.listener = document.addEventListener('keyup', (event) => {
+    this.listener = (event) => {
       let { key } = event;
 
       if (key === 'Escape') {
         this.onClose(event);
       }
-    });
+    };
+
+    document.addEventListener('keyup', this.listener);
   },
 
   willDestroyElement() {


### PR DESCRIPTION
Previously, the super-modal component's `this.listener` was set to the return value of `document.addEventListener()` rather than the actual keyup handler. This meant that on `willDestroyElement` the listener was not actually removed. This caused a) a memory leak, and b) console errors in the consuming app, when consuming component's `onClose` handlers were called after the components had already been destroyed.